### PR TITLE
sd-650: remove istanbul-instrumenter-loader because it's deprecated …

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -21,7 +21,7 @@ module.exports = function(config) {
       'tests.utils.webpack.js': ['webpack'],
       'tests.server.webpack.js': ['webpack']
     },
-    reporters: ['mocha', 'junit', 'coverage'],
+    reporters: ['mocha', 'junit'],
     junitReporter: {
       outputDir: 'output'
     },
@@ -35,19 +35,6 @@ module.exports = function(config) {
     webpackMiddleware: {
       noInfo: true,
       quiet: true
-    },
-    coverageReporter: {
-      includeAllSources: true,
-      dir: 'coverage/',
-      reporters: [{
-        type: 'html'
-      }, {
-        type: 'cobertura'
-      }, {
-        type: 'lcovonly',
-        file: 'lcov.info',
-        subdir: '.'
-      }]
     }
   });
 };

--- a/package.json
+++ b/package.json
@@ -141,8 +141,6 @@
     "estraverse-fb": "^1.3.1",
     "expect": "^1.14.0",
     "glob": "^7.0.3",
-    "isparta-loader": "^2.0.0",
-    "istanbul-instrumenter-loader": "^0.2.0",
     "jsdom": "^9.0.0",
     "jsdom-global": "^2.0.0",
     "json-loader": "^0.5.2",


### PR DESCRIPTION
…and we don't use coverage anyway.