### PR TITLE
Issue #218: Fixed LibraryDetailAction

### DIFF
--- a/src/client/Actions/agency.actions.js
+++ b/src/client/Actions/agency.actions.js
@@ -11,17 +11,16 @@ const getLibraryDetails = SocketClient('getLibraryDetails');
 
 export function asyncGetLibraryDetailsAction(query) {
   return function(dispatch) {
-    getLibraryDetails.response((res) => {
-      dispatch(getLibraryDetailsAction(query, res.pickupAgency || {}));
+    getLibraryDetails.responseOnce((res) => {
+      dispatch(getLibraryDetailsAction(res.pickupAgency || {}));
     });
     getLibraryDetails.request(query);
   };
 }
 
-export function getLibraryDetailsAction(query, elements) {
+export function getLibraryDetailsAction(pickupAgency) {
   return {
     type: types.GET_LIBRARY_DETAILS,
-    query,
-    elements
+    pickupAgency
   };
 }

--- a/src/client/Reducers/agency.reducer.js
+++ b/src/client/Reducers/agency.reducer.js
@@ -13,10 +13,10 @@ export default function entitySuggestReducer(state = initialState, action = {}) 
   Object.freeze(state);
   switch (action.type) {
     case GET_LIBRARY_DETAILS: {
-      const agencyId = action.query.agencyId;
-      let newState = {};
-      newState[agencyId] = action.elements;
-
+      const agencyId = action.pickupAgency.isil || `DK-${action.pickupAgency.branchId}`;
+      const newState = {
+        [agencyId]: action.pickupAgency
+      };
       return assignToEmpty(state, newState);
     }
 


### PR DESCRIPTION
response should only be triggered once, and AgencyId is taken from response instead of query to prevent race conditions.