### PR TITLE
tweaking Editorially Selected materials (and CompactWorkElement)

### DIFF
--- a/src/client/components/WidgetContainer/widgets/BestRatedWorksWidget/compactWorkElement.component.js
+++ b/src/client/components/WidgetContainer/widgets/BestRatedWorksWidget/compactWorkElement.component.js
@@ -32,7 +32,7 @@ export class CompactWorkElement extends Component {
     const title = work.dcTitle;
     const workType = work.workType || 'other';
     const workTypeSvg = materialSvgs[workType];
-    const cover = work.coverUrlFull;
+    const cover = work.coverUrl;
     const pid = work.collection[0];
 
     return (

--- a/src/client/components/WidgetContainer/widgets/BestRatedWorksWidget/scss/compactWorkElement.component.scss
+++ b/src/client/components/WidgetContainer/widgets/BestRatedWorksWidget/scss/compactWorkElement.component.scss
@@ -34,7 +34,7 @@
   }
 
   .compact-work-element--artwork-container > img {
-    height: 200px;
+    max-height: 200px;
     max-width: 133px;
     object-fit: cover;
   }

--- a/src/client/components/WidgetContainer/widgets/EditoriallySelectedMaterialsWidget/EditoriallySelectedMaterials.widget.component.js
+++ b/src/client/components/WidgetContainer/widgets/EditoriallySelectedMaterialsWidget/EditoriallySelectedMaterials.widget.component.js
@@ -22,7 +22,8 @@ export class EditoriallySelectedMaterialsWidget extends AbstractWidget {
 
     this.state = {
       closed: true,
-      works: Object.values(props.widgetReducerProp.works)
+      works: Object.values(props.widgetReducerProp.works),
+      isLoading: props.widgetReducerProp.isLoading
     };
   }
 
@@ -34,7 +35,7 @@ export class EditoriallySelectedMaterialsWidget extends AbstractWidget {
 
   componentWillReceiveProps(nextProps) {
     const works = Object.values(nextProps.widgetReducerProp.works);
-    this.setState({works});
+    this.setState({works, isLoading: false});
   }
 
   componentDidMount() {
@@ -48,15 +49,15 @@ export class EditoriallySelectedMaterialsWidget extends AbstractWidget {
     if (this.state.closed) {
       closeButtonContent = (
         <span>
-          <Icon glyph={plusSvg}/> VIS FLERE
-        </span>
+        <Icon glyph={plusSvg}/> VIS FLERE
+      </span>
       );
     }
     else {
       closeButtonContent = (
         <span>
-          <Icon glyph={minusSvg}/> VIS FÆRRE
-        </span>
+        <Icon glyph={minusSvg}/> VIS FÆRRE
+      </span>
       );
     }
 
@@ -64,13 +65,16 @@ export class EditoriallySelectedMaterialsWidget extends AbstractWidget {
       <div className="editorially-selected-materials-widget">
         <CompactWorkElementsContainer
           closed={this.state.closed}
-          isLoading={this.props.widgetReducerProp.isLoading}
+          isLoading={this.state.isLoading}
           works={works} />
 
         <div className="editorially-selected-materials-widget--show-more-button--container">
+          {
+            !this.state.isLoading &&
           <a className="editorially-selected-materials-widget--show-more-button" onClick={() => this.setState({closed: !this.state.closed})}>
             {closeButtonContent}
           </a>
+          }
           <hr />
         </div>
 

--- a/src/client/components/WidgetContainer/widgets/EditoriallySelectedMaterialsWidget/scss/EditoriallySelectedMaterials.widget.component.scss
+++ b/src/client/components/WidgetContainer/widgets/EditoriallySelectedMaterialsWidget/scss/EditoriallySelectedMaterials.widget.component.scss
@@ -3,6 +3,7 @@
 .editorially-selected-materials-widget {
   text-align: center;
   margin-top: 10px;
+  padding-bottom: 15px;
 }
 
 .editorially-selected-materials-widget--show-more-button--container {


### PR DESCRIPTION
- avoid cropping cover images (e.g for games or music)
- Using CoverUrl as in searchresults (so that default icons work)
- Giving more space to showmore button