### PR TITLE
Fix count request to community service

### DIFF
--- a/src/server/serviceProvider/transformers/Community/Reviews/getReview.transform.js
+++ b/src/server/serviceProvider/transformers/Community/Reviews/getReview.transform.js
@@ -7,7 +7,7 @@ const GetReviewTransform = {
 
   requestTransform(event, {id, pids, skip, limit, where, order='created DESC'}, connection) {
     return new Promise((resolve, reject) => {
-      const user = connection.request.user || {id: ''};
+      const user = connection.request.user || {id: null};
       const accessToken = user.id;
       let orFilter = [];
       let params = {


### PR DESCRIPTION
when access_token is set to an empty string, count request will fail.