### PR TITLE
Only fetch reviews for single pid

### DIFF
--- a/src/server/routes/work.routes.js
+++ b/src/server/routes/work.routes.js
@@ -107,7 +107,7 @@ WorkRoutes.get('/:pid', async (req, res, next) => {
     const work = workResult.data[0];
 
     let ownReviewId;
-    let pids = Array.isArray(work.collection) ? work.collection : [pid];
+    let pids = [pid];
 
     let profile = {
       userIsLoggedIn: false,


### PR DESCRIPTION
This is a quickfix to enable multiple reviews on multivolume works.

Part of #853 